### PR TITLE
:+1:storeをページごとに切り分けた

### DIFF
--- a/src/store/edit.js
+++ b/src/store/edit.js
@@ -1,0 +1,10 @@
+export default {
+  state: {
+  },
+  getters: {
+  },
+  mutations: {
+  },
+  actions: {
+  }
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,19 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import edit from './edit'
+import login from './login'
+import main from './main'
+import result from './result'
+import user from './user'
+
+Vue.use(Vuex)
+
+export default new Vuex.Store({
+  modules: {
+    edit,
+    login,
+    main,
+    result,
+    user
+  }
+})

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -10,10 +10,25 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   modules: {
-    edit,
-    login,
-    main,
-    result,
-    user
+    edit: {
+      namespaced: true,
+      ...edit
+    },
+    login: {
+      namespaced: true,
+      ...login
+    },
+    main: {
+      namespaced: true,
+      ...main
+    },
+    result: {
+      namespaced: true,
+      ...result
+    },
+    user: {
+      namespaced: true,
+      ...user
+    }
   }
 })

--- a/src/store/login.js
+++ b/src/store/login.js
@@ -1,0 +1,10 @@
+export default {
+  state: {
+  },
+  getters: {
+  },
+  mutations: {
+  },
+  actions: {
+  }
+}

--- a/src/store/main.js
+++ b/src/store/main.js
@@ -1,0 +1,10 @@
+export default {
+  state: {
+  },
+  getters: {
+  },
+  mutations: {
+  },
+  actions: {
+  }
+}

--- a/src/store/result.js
+++ b/src/store/result.js
@@ -1,0 +1,10 @@
+export default {
+  state: {
+  },
+  getters: {
+  },
+  mutations: {
+  },
+  actions: {
+  }
+}

--- a/src/store/user.js
+++ b/src/store/user.js
@@ -1,10 +1,6 @@
-import Vue from 'vue'
-import Vuex from 'vuex'
-import { fetchMain } from './api'
+import { fetchMain } from '../api'
 
-Vue.use(Vuex)
-
-export default new Vuex.Store({
+export default {
   state: {
     user: {},
     cosmes: {
@@ -30,4 +26,4 @@ export default new Vuex.Store({
       commit('updateMainData', mainData)
     }
   }
-})
+}

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -31,7 +31,7 @@ export default {
   },
   computed: {
     list() {
-      return this.$store.getters.cosmes(this.type)
+      return this.$store.getters["user/cosmes"](this.type)
     }
   }
 };

--- a/src/views/Edit.vue
+++ b/src/views/Edit.vue
@@ -31,7 +31,7 @@ export default {
   },
   computed: {
     list() {
-      return this.$store.getters["user/cosmes"](this.type)
+      return this.$store.getters['user/cosmes'](this.type)
     }
   }
 };

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -30,12 +30,12 @@ export default {
   },
   computed: {
     name() {
-      return this.$store.getters["user/user"].name
+      return this.$store.getters['user/user'].name
     },
     all() {
-      return this.$store.getters["user/cosmeTypes"].map(type => ({ 
+      return this.$store.getters['user/cosmeTypes'].map(type => ({ 
         label: type,
-        list: this.$store.getters["user/cosmes"](type)
+        list: this.$store.getters['user/cosmes'](type)
       }))
     }
   },

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -30,17 +30,17 @@ export default {
   },
   computed: {
     name() {
-      return this.$store.getters.user.name
+      return this.$store.getters["user/user"].name
     },
     all() {
-      return this.$store.getters.cosmeTypes.map(type => ({ 
+      return this.$store.getters["user/cosmeTypes"].map(type => ({ 
         label: type,
-        list: this.$store.getters.cosmes(type)
+        list: this.$store.getters["user/cosmes"](type)
       }))
     }
   },
   created() {
-    this.$store.dispatch('loadMain')
+    this.$store.dispatch('user/loadMain')
   }
 }
 </script>


### PR DESCRIPTION
- 現状すべてuserのstoreのようだったので他は空storeを配置
- Edit.vueからuserのstoreのgetterにアクセスしているが、問題にならないのか要検討
- ~~stateはstoreモジュールごとに分かれているのでアクセスする場合は```store.state.<モジュール名>```とする必要があるが、getters / mutations / actions はstoreモジュールごとに分かれていないので、これらは今まで通りにアクセスできる~~
  - ~~store全体で各モジュールのメソッドたちが共有されるということ~~
  - ~~モジュール内ではなく、store全体でユニークな命名をする必要がありそう~~