### PR TITLE
B. ある分野のコスメの一覧ボタンでその分野の持っているコスメのリストを全て表示

### DIFF
--- a/src/store/module/pages/main.js
+++ b/src/store/module/pages/main.js
@@ -3,15 +3,15 @@ export default {
     cosmeStates: {
       base: {
         isChecked: true,
-        isOpend: false
+        isOpened: false
       },
       cheek: {
         isChecked: true,
-        isOpend: false
+        isOpened: false
       },
       lip: {
         isChecked: true,
-        isOpend: false
+        isOpened: false
       }
     }
   },
@@ -20,8 +20,7 @@ export default {
   },
   mutations: {
     changeDisplayState(state, payload) {
-      state.cosmeStates[payload].isOpend = !state.cosmeStates[payload].isOpend
-      alert(state.cosmeStates[payload].isOpend)
+      state.cosmeStates[payload].isOpened = !state.cosmeStates[payload].isOpened
     }
   },
   actions: {

--- a/src/store/module/user-data.js
+++ b/src/store/module/user-data.js
@@ -14,9 +14,7 @@ export default {
     user: state => state.user,
     cosmeTypes: state => Object.keys(state.cosmes),
     cosmes: state => state.cosmes,
-    cosmeIdCount: state => {
-      return state.cosmeIdCount
-    }
+    cosmeIdCount: state => state.cosmeIdCount
   },
   mutations: {
     updateMainData(state, payload) {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -5,18 +5,20 @@
       <Sidebar PageName="メイン"/>
       <main>
         <h2>今日のコスメを決めよう！</h2>
-        <div v-for="category in limitedItems" :key="category.label" class="category">
-          <h3 class="category-label">{{ category.label }}</h3>
-          <button class="displayDetail" @click="changeState(category.label)">詳細</button>
-          <ul class="list">
-           <li v-for="item in category.list" :key="item.id" class="item">{{ item.name }}
-              <ul class="cosme-info">
-                <li> {{ item.brand }} </li>
-                <li> {{ item.color }} </li>
-              </ul>
-           </li>
-          </ul>
-        </div>
+        <section>
+          <div v-for="category in cosmeList" :key="category.label" class="category">
+            <h3 class="category-label">{{ category.label }}</h3>
+            <button v-if="category.isOpened" @click="changeState(category.label)">▲</button>
+            <button v-else @click="changeState(category.label)">▼</button>
+            <ul class="list">
+              <li v-for="item in category.list" :key="item.id" class="item">- cosme list -
+                <ul>
+                  <li v-for="( info, key ) in item" :key="key" class="key"> {{ key }}: {{ info }} </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </section>
         <router-link class="link" to="/main/result">結果を画像で保存</router-link>
       </main>
     </div>
@@ -34,20 +36,25 @@ export default {
     Sidebar
   },
   computed: {
-    limitedItems() {
+    cosmeList() {
       return this.$store.getters['userData/cosmeTypes'].map(type => {
-        const list = this.$store.getters['userData/cosmes'][type].slice(0, 1)
-        return {
-          label: type,
-          list
+        const isOpened = this.$store.getters['pages/main/cosmeStates'][type].isOpened
+        const list = this.$store.getters['userData/cosmes'][type]
+
+        if(isOpened) {
+          return {
+            isOpened,
+            label: type,
+            list
+          }
+        } else {
+          return {
+            isOpened,
+            label: type,
+            list: list.slice(0, 1)
+          }
         }
       })
-    },
-    allItems() {
-      return this.$store.getters['userData/cosmeTypes'].map(type => ({
-        label: type,
-        list: this.$store.getters['userData/cosmes'][type]
-      }))
     }
   },
   methods: {


### PR DESCRIPTION
- 変更1
タイプミスを修正

- 変更2
マークアップの構造,属性の命名をちょっと変更

- 変更3
コスメの表示の切り替えをcomputedの関数の中のif文で切り替える形に変更
→`v-if`の使用も考えたが、`<template></template>`内が見にくくなったので不採用
→リストの部分の子コンポーネントを作成することも考えたが`v-for`やチェックフォームなどとの兼ね合いなどで複雑になったのでどちらがいいか悩み中(ユーザーページでも同じようなチェックフォームなしの同じようなリストがある)