### PR TITLE
mo/feature/add-checkbox-for-all-modules

### DIFF
--- a/src/components/TypeList.vue
+++ b/src/components/TypeList.vue
@@ -1,10 +1,9 @@
 <template>
   <ul class="list">
-    {{ checkedItem }}
     <li v-for="item in category.list" :key="item.id" class="item">
       <div class="item-function">
         <span>- cosme list -</span>
-        <input type="checkbox" v-model="checkedItems" :value="item.id">
+        <input type="checkbox" v-model="isChecked" :value="item.id">
       </div>
       <ul>
         <li v-for="( info, key ) in item" :key="key" class="key"> {{ key }}: {{ info }} </li>
@@ -25,12 +24,19 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('userData', [
-      'allCosmeIds'
+    ...mapGetters('pages/main', [
+      'checkedItems'
     ]),
-    checkedItems: {
+    isChecked: {
       get() {
-        return this.allCosmeIds[this.category.label]
+        return this.checkedItems[this.category.label]
+      },
+      set(value) {
+        const data = {
+          type: this.category.label,
+          cosmes: value
+        }
+        this.$store.dispatch('pages/main/loadCheckedItems', data)
       }
     }
   }

--- a/src/components/TypeList.vue
+++ b/src/components/TypeList.vue
@@ -1,0 +1,38 @@
+<template>
+  <ul class="list">
+    {{ checkedItem }}
+    <li v-for="item in category.list" :key="item.id" class="item">
+      <div class="item-function">
+        <span>- cosme list -</span>
+        <input type="checkbox" v-model="checkedItems" :value="item.id">
+      </div>
+      <ul>
+        <li v-for="( info, key ) in item" :key="key" class="key"> {{ key }}: {{ info }} </li>
+      </ul>
+    </li>
+  </ul>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'type-list',
+  props: {
+    category: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    ...mapGetters('userData', [
+      'allCosmeIds'
+    ]),
+    checkedItems: {
+      get() {
+        return this.allCosmeIds[this.category.label]
+      }
+    }
+  }
+}
+</script>

--- a/src/store/module/pages/main.js
+++ b/src/store/module/pages/main.js
@@ -1,31 +1,38 @@
 export default {
   state: {
     cosmeStates: {
-      base: {
-        isChecked: true,
-        isOpened: false
+      isOpened: {
+        base: false,
+        cheek: false,
+        lip: false
       },
-      cheek: {
-        isChecked: true,
-        isOpened: false
-      },
-      lip: {
-        isChecked: true,
-        isOpened: false
+      checkedTypes: [],
+      checkedItems: {
+        base: [],
+        cheek: [],
+        lip: []
       }
     }
   },
   getters: {
-    cosmeStates: state => state.cosmeStates
+    cosmeStates: state => state.cosmeStates,
+    isOpened: state => state.cosmeStates.isOpened
   },
   mutations: {
     changeDisplayState(state, payload) {
-      state.cosmeStates[payload].isOpened = !state.cosmeStates[payload].isOpened
+      state.cosmeStates.isOpened[payload] = !state.cosmeStates.isOpened[payload]
     }
+    // updateCheckedModules(state, payload) {
+    //   state.checkedTypes = payload.checkedTypes
+    //   state.checkedItems = payload.checkedItems
+    // }
   },
   actions: {
     loadDisplayState({ commit }, payload) {
       commit('changeDisplayState', payload)
     }
+    // loadCheckedModules({ commit }, payload) {
+    //   commit('updateCheckedModules', payload)
+    // }
   }
 }

--- a/src/store/module/pages/main.js
+++ b/src/store/module/pages/main.js
@@ -21,18 +21,24 @@ export default {
   mutations: {
     changeDisplayState(state, payload) {
       state.cosmeStates.isOpened[payload] = !state.cosmeStates.isOpened[payload]
+    },
+    updateCheckedTypes(state, payload) {
+      if (state.checkedTypes)
+        state.checkedTypes = payload
+    },
+    updateCheckedCosmes(state, payload) {
+      state.checkedCosmes = payload
     }
-    // updateCheckedModules(state, payload) {
-    //   state.checkedTypes = payload.checkedTypes
-    //   state.checkedItems = payload.checkedItems
-    // }
   },
   actions: {
     loadDisplayState({ commit }, payload) {
       commit('changeDisplayState', payload)
+    },
+    loadCheckedTypes({ commit }, payload) {
+      commit('updateCheckedTypes', payload)
+    },
+    loadCheckedCosmes({ commit }, payload) {
+      commit('updateCheckedCosmes', payload)
     }
-    // loadCheckedModules({ commit }, payload) {
-    //   commit('updateCheckedModules', payload)
-    // }
   }
 }

--- a/src/store/module/pages/main.js
+++ b/src/store/module/pages/main.js
@@ -16,6 +16,8 @@ export default {
   },
   getters: {
     cosmeStates: state => state.cosmeStates,
+    checkedTypes: state => state.cosmeStates.checkedTypes,
+    checkedItems: state => state.cosmeStates.checkedItems,
     isOpened: state => state.cosmeStates.isOpened
   },
   mutations: {
@@ -23,11 +25,10 @@ export default {
       state.cosmeStates.isOpened[payload] = !state.cosmeStates.isOpened[payload]
     },
     updateCheckedTypes(state, payload) {
-      if (state.checkedTypes)
-        state.checkedTypes = payload
+      state.cosmeStates.checkedTypes = payload
     },
-    updateCheckedCosmes(state, payload) {
-      state.checkedCosmes = payload
+    updateCheckedItems(state, payload) {
+      state.cosmeStates.checkedItems[payload.type] = payload.cosmes
     }
   },
   actions: {
@@ -37,8 +38,8 @@ export default {
     loadCheckedTypes({ commit }, payload) {
       commit('updateCheckedTypes', payload)
     },
-    loadCheckedCosmes({ commit }, payload) {
-      commit('updateCheckedCosmes', payload)
+    loadCheckedItems({ commit }, payload) {
+      commit('updateCheckedItems', payload)
     }
   }
 }

--- a/src/store/module/user-data.js
+++ b/src/store/module/user-data.js
@@ -15,7 +15,7 @@ export default {
     cosmeTypes: state => Object.keys(state.cosmes),
     allCosmeIds: state => ({
       base: state.cosmes.base.map(item => item.id),
-      cheel: state.cosmes.cheek.map(item => item.id),
+      cheek: state.cosmes.cheek.map(item => item.id),
       lip: state.cosmes.lip.map(item => item.id)
       //もっといい書き方ありませんか
     }),

--- a/src/store/module/user-data.js
+++ b/src/store/module/user-data.js
@@ -13,6 +13,12 @@ export default {
   getters: {
     user: state => state.user,
     cosmeTypes: state => Object.keys(state.cosmes),
+    allCosmeIds: state => ({
+      base: state.cosmes.base.map(item => item.id),
+      cheel: state.cosmes.cheek.map(item => item.id),
+      lip: state.cosmes.lip.map(item => item.id)
+      //もっといい書き方ありませんか
+    }),
     cosmes: state => state.cosmes,
     cosmeIdCount: state => state.cosmeIdCount
   },

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -10,7 +10,7 @@
           <div v-for="category in cosmeList" :key="category.label" class="category">
             <div class="category-fuction">
               <span class="category-label">{{ category.label }}</span>
-              <input type="checkbox" v-model="checkedTypes" :value="category.label">
+              <input type="checkbox" v-model="isChecked" :value="category.label" >
               <button v-if="category.isOpened" @click="changeState(category.label)">▲</button>
               <button v-else @click="changeState(category.label)">▼</button>
             </div>
@@ -43,8 +43,8 @@ export default {
       'cosmes'
     ]),
     ...mapGetters('pages/main', [
-      'isOpened'
-
+      'isOpened',
+      'checkedTypes'
     ]),
     cosmeList() {
       return this.cosmeTypes.map(type => {
@@ -66,9 +66,12 @@ export default {
         }
       })
     },
-    checkedTypes: {
+    isChecked: {
       get() {
-        return this.cosmeTypes
+        return this.checkedTypes
+      },
+      set(value) {
+        this.$store.dispatch('pages/main/loadCheckedTypes', value)
       }
     }
   },

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -10,21 +10,11 @@
           <div v-for="category in cosmeList" :key="category.label" class="category">
             <div class="category-fuction">
               <span class="category-label">{{ category.label }}</span>
-              <input type="checkbox" v-model="checkedTypes" v-bind:value="category.label">
+              <input type="checkbox" v-model="checkedTypes" :value="category.label">
               <button v-if="category.isOpened" @click="changeState(category.label)">▲</button>
               <button v-else @click="changeState(category.label)">▼</button>
             </div>
-            <ul class="list">
-              <li v-for="item in category.list" :key="item.id" class="item">
-                <div class="item-function">
-                  <span>- cosme list -</span>
-                  <input type="checkbox" v-model="checkedItems[category.label]" v-bind:value="item.id">
-                </div>
-                <ul>
-                  <li v-for="( info, key ) in item" :key="key" class="key"> {{ key }}: {{ info }} </li>
-                </ul>
-              </li>
-            </ul>
+            <type-list :category="category"></type-list>
           </div>
         </section>
         <router-link class="link" to="/main/result">結果を画像で保存</router-link>
@@ -36,22 +26,23 @@
 <script>
 import Header from '@/components/Header.vue'
 import Sidebar from '@/components/Sidebar.vue'
+import TypeList from '@/components/TypeList.vue'
+
 import { mapGetters } from 'vuex'
 
 export default {
   name: 'main-page',
   components: {
     Header,
-    Sidebar
+    Sidebar,
+    TypeList
   },
   computed: {
     ...mapGetters('userData', [
       'cosmeTypes',
-      'cosmes',
-      'allCosmeIds'
+      'cosmes'
     ]),
     ...mapGetters('pages/main', [
-      'cosmeStates',
       'isOpened'
 
     ]),
@@ -74,21 +65,16 @@ export default {
           }
         }
       })
+    },
+    checkedTypes: {
+      get() {
+        return this.cosmeTypes
+      }
     }
   },
   methods: {
     changeState(type) {
       this.$store.dispatch('pages/main/loadDisplayState', type)
-    }
-  },
-  data() {
-    return {
-      checkedTypes: [],
-      checkedItems: {
-        base: [],
-        cheek: [],
-        lip: []
-      }
     }
   },
   created() {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -4,14 +4,22 @@
     <div class="row">
       <Sidebar PageName="メイン"/>
       <main>
-        <h2>今日のコスメを決めよう！</h2>
+        <h1>今日のコスメを決めよう！</h1>
         <section>
+          <h2>コスメを選択しよう！</h2>
           <div v-for="category in cosmeList" :key="category.label" class="category">
-            <h3 class="category-label">{{ category.label }}</h3>
-            <button v-if="category.isOpened" @click="changeState(category.label)">▲</button>
-            <button v-else @click="changeState(category.label)">▼</button>
+            <div class="category-fuction">
+              <span class="category-label">{{ category.label }}</span>
+              <input type="checkbox" v-model="checkedTypes" v-bind:value="category.label">
+              <button v-if="category.isOpened" @click="changeState(category.label)">▲</button>
+              <button v-else @click="changeState(category.label)">▼</button>
+            </div>
             <ul class="list">
-              <li v-for="item in category.list" :key="item.id" class="item">- cosme list -
+              <li v-for="item in category.list" :key="item.id" class="item">
+                <div class="item-function">
+                  <span>- cosme list -</span>
+                  <input type="checkbox" v-model="checkedItems[category.label]" v-bind:value="item.id">
+                </div>
                 <ul>
                   <li v-for="( info, key ) in item" :key="key" class="key"> {{ key }}: {{ info }} </li>
                 </ul>
@@ -28,6 +36,7 @@
 <script>
 import Header from '@/components/Header.vue'
 import Sidebar from '@/components/Sidebar.vue'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'main-page',
@@ -36,10 +45,20 @@ export default {
     Sidebar
   },
   computed: {
+    ...mapGetters('userData', [
+      'cosmeTypes',
+      'cosmes',
+      'allCosmeIds'
+    ]),
+    ...mapGetters('pages/main', [
+      'cosmeStates',
+      'isOpened'
+
+    ]),
     cosmeList() {
-      return this.$store.getters['userData/cosmeTypes'].map(type => {
-        const isOpened = this.$store.getters['pages/main/cosmeStates'][type].isOpened
-        const list = this.$store.getters['userData/cosmes'][type]
+      return this.cosmeTypes.map(type => {
+        const isOpened = this.isOpened[type]
+        const list = this.cosmes[type]
 
         if(isOpened) {
           return {
@@ -60,6 +79,16 @@ export default {
   methods: {
     changeState(type) {
       this.$store.dispatch('pages/main/loadDisplayState', type)
+    }
+  },
+  data() {
+    return {
+      checkedTypes: [],
+      checkedItems: {
+        base: [],
+        cheek: [],
+        lip: []
+      }
     }
   },
   created() {


### PR DESCRIPTION
### 変更
- 変更1
チェックボックスを実装するためにstateの構造を変更

- 変更2
チェックボックスがtrueならコンポーネントのdata内にid(type)が入るように実装

###  質問
- 質問1
チェックボックスを初期状態がcheckedの状態にしたいのにchecked属性が使えないです。どうすれば良いですか？

- 質問2
チェックボックスの状態はページ遷移しても維持したいのでstoreに保存したいのですが、storeへ保存するタイミングとそれを読み込んでチェックボックスの状態を復元する方法を知りたいです。
(最悪実装できなくてもいいです)